### PR TITLE
ci: pin forked sync action to commit fixing rev-list ambiguity

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -24,7 +24,7 @@ jobs:
       # Step 2: run the sync action
       - name: Sync upstream changes
         id: sync
-        uses: aormsby/fork-sync-with-upstream-action@83d78e8c4bf524e79b091cf257deba4dee9e60df # v3.4.3
+        uses: Shinku-Chen/fork-sync-with-upstream-action@66925e8bb37b2590950a72d786b308e4f1b5301f # TEMP: v3.4.3 + fix for `rev-list` ambiguous branch/dir `main` (upstream PR aormsby/Fork-Sync-With-Upstream-action#85); switch back to aormsby release once merged
         with:
           upstream_sync_repo: FoloToy/ai-passport
           upstream_sync_branch: main


### PR DESCRIPTION
## Summary

The upstream sync action referenced in `sync-main.yml`,
`aormsby/fork-sync-with-upstream-action@v3.4.3`, fails whenever the target
branch name collides with a real directory in the repository. This repo has a
`main/` directory at its root while the sync target branch is also `main`, so
every fork running this workflow aborts with:

```
fatal: ambiguous argument 'main': both revision and filename
```

This PR points the action pin at a fork commit that carries the fix (append
`--` to the `git rev-list` calls so a branch name matching a directory is not
read as a path), restoring the daily fork-sync for all forks of this repo.

## Scope and compatibility

- Affected board/revision: None (CI configuration only)
- Affected subsystem: `.github/workflows/sync-main.yml`
- Wiring or pin-map impact: None
- Flash, partition, or persistent-data impact: None
- Backward-compatibility impact: The workflow behavior is unchanged apart from
  the action reference it runs, so every fork continues to sync against
  `FoloToy/ai-passport:main`.

## Verification

| Check | Result | Evidence or notes |
| --- | --- | --- |
| Build | NOT RUN | No firmware or C code changed; CI YAML only |
| Host tests | PASS | `./tools/validate.sh --static` — actionlint + repository checks passed |
| Device tests | NOT RUN | No hardware behavior changed |
| Unverified | — | None |

Commands run:

```text
./tools/validate.sh --static
```

## Device evidence

N/A — no hardware or device-visible behavior is changed by this PR.

## Follow-up

This points the pin at a fork commit because the upstream
`aormsby/Fork-Sync-With-Upstream-action` has not yet released a version
containing the fix. Once aormsby/Fork-Sync-With-Upstream-action#85 is merged
and tagged, this reference should be switched back to the official `aormsby`
release (see related comment in Shinku-Chen/ai-passport#2).

## Checklist

- [x] I reviewed the complete diff and excluded unrelated/generated files.
- [x] I ran the relevant validation command or explained why it was not run.
- [x] I separated build, host-test, and device-test results.
- [x] I updated authoritative documentation for changed hardware facts or durable behavior.
- [x] I updated `docs/CHANGELOG.md` if this changes user-visible behavior, compatibility, or release workflow.
- [x] I removed credentials, private device links, personal data, and unsanitized logs.
