### PR TITLE
ci: pin forked sync action to commit fixing rev-list ambiguity

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -24,7 +24,7 @@ jobs:
       # Step 2: run the sync action
       - name: Sync upstream changes
         id: sync
-        uses: aormsby/fork-sync-with-upstream-action@83d78e8c4bf524e79b091cf257deba4dee9e60df # v3.4.3
+        uses: Shinku-Chen/fork-sync-with-upstream-action@66925e8bb37b2590950a72d786b308e4f1b5301f # TEMP: v3.4.3 + fix for `rev-list` ambiguous branch/dir `main` (upstream PR aormsby/Fork-Sync-With-Upstream-action#85); switch back to aormsby release once merged
         with:
           upstream_sync_repo: FoloToy/ai-passport
           upstream_sync_branch: main


### PR DESCRIPTION
## Summary

The upstream `aormsby/fork-sync-with-upstream-action` v3.4.3 aborts the daily
fork-sync workflow when the target branch name collides with a real directory in
the repository. In `ai-passport` the branch is `main` while `docs/` history once
included a `main/` path, so the action fails with:

```
ambiguous argument 'main'
```

This PR points the pin temporarily at the fork that carries the fix (upstream
PR aormsby/Fork-Sync-With-Upstream-action#85) so the sync can run. Revert to the
official `aormsby` release once the fix is merged and tagged upstream.

## Scope and compatibility

- Affected board/revision: None (CI-only change)
- Affected subsystem: `.github/workflows/sync-main.yml`
- Wiring or pin-map impact: None
- Flash, partition, or persistent-data impact: None
- Backward-compatibility impact: None

## Verification

| Check | Result | Evidence or notes |
| --- | --- | --- |
| Build | NOT RUN | CI-only workflow change; no firmware code touched |
| Host tests | NOT RUN | No host tests affected |
| Device tests | NOT RUN | No hardware behavior affected |
| Unverified | — | The action pin itself is exercised only when the daily sync runs; a follow-up can confirm the first successful sync |

Commands run:

```text
none (no source/build change)
```

## Device evidence

N/A — no hardware or display change.

## Checklist

- [x] I reviewed the complete diff and excluded unrelated/generated files.
- [x] I ran the relevant validation command or explained why it was not run.
- [x] I separated build, host-test, and device-test results.
- [x] I updated authoritative documentation for changed hardware facts or durable behavior.
- [ ] I updated `docs/CHANGELOG.md` if this changes user-visible behavior, compatibility, or release workflow.
- [x] I removed credentials, private device links, personal data, and unsanitized logs.
