### PR TITLE
fix(ci): use fail_on_unmatched_files for action-gh-release

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -69,4 +69,4 @@ jobs:
         with:
           name: "${{ github.ref_name }}"
           files: release/FoloToy-AI-Passport-full.bin
-          if-no-files-found: error
+          fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary

The `softprops/action-gh-release@v2` step in the tag-triggered Release job passes an `if-no-files-found` input that the action does not support (valid inputs include `fail_on_unmatched_files`). Each tag release logs:

```
Unexpected input(s) 'if-no-files-found', valid inputs are [...] fail_on_unmatched_files ...
```

It is not only log noise: because the input is ignored, the Release step will not fail when the firmware path does not match, and a Release without firmware could be published.

## Scope and compatibility

- Affected board/revision: None (CI workflow change only)
- Affected subsystem: GitHub Actions release workflow
- Wiring or pin-map impact: None
- Flash, partition, or persistent-data impact: None
- Backward-compatibility impact: None. Replaces the unsupported input with the equivalent supported one on `softprops/action-gh-release`; the `actions/upload-artifact` step keeps its own (valid) `if-no-files-found: error`.

## Verification

| Check | Result | Evidence or notes |
| --- | --- | --- |
| Build | NOT RUN | No firmware source changed. |
| Host tests | PASS | `./tools/validate.sh --static` — repository checks + host tests. |
| Device tests | NOT RUN | No device or hardware change. |
| Unverified | — | Tag-triggered Release not actually run; this change only touches the release step input. |

Commands run:

```text
./tools/validate.sh --static
```

## Device evidence

Not applicable — CI workflow change only.

## Checklist

- [x] I reviewed the complete diff and excluded unrelated/generated files.
- [x] I ran the relevant validation command or explained why it was not run.
- [x] I separated build, host-test, and device-test results.
- [x] I updated authoritative documentation for changed hardware facts or durable behavior.
- [x] I updated `docs/CHANGELOG.md` if this changes user-visible behavior, compatibility, or release workflow.
- [x] I removed credentials, private device links, personal data, and unsanitized logs.
