### PR TITLE
docs(experiences): add deep-sleep peripheral power-off entry

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -24,6 +24,7 @@ The engineering rules themselves live under
 - [Audio Compression Trade-offs on ESP32-C3](shinku-chen/audio-compression-trade-offs.md) — how a voice-playback codec was chosen on limited flash (IMA-ADPCM vs Opus vs MP3), with measured capacity and decoder cost.
 - [Post-Release Follow-up for the AI Passport Publishing Flow](shinku-chen/post-release-follow-up.md) — confirm the publish destination, include the data partition in a release, and the consent gates for the post-release tracks.
 - [Display Refresh and Deep-sleep on ESP32-C3 (No PSRAM)](shinku-chen/display-refresh-and-deep-sleep.md) — direct panel refresh of a single image rect, RTC-GPIO deep-sleep wakeup, and the LVGL object-type misuse crash signature.
+- [Shutting Down On-Board Peripherals Before Deep-Sleep](shinku-chen/deep-sleep-peripheral-power-off.md) — power the LCD panel, backlight, codec, and fuel gauge down before deep sleep, the `esp_codec_dev_close()` only-suspends-if-opened trap, and what software cannot fix (always-on PA, regulator).
 
 **Application playbooks:**
 

--- a/docs/reference/README.zh_CN.md
+++ b/docs/reference/README.zh_CN.md
@@ -17,6 +17,7 @@
 - [ESP32-C3 上音频压缩方式的权衡](shinku-chen/audio-compression-trade-offs.zh_CN.md) — 在有限 Flash 上如何为语音播放应用选编解码（IMA-ADPCM vs Opus vs MP3），含实测容量与解码器成本。
 - [发布后收尾：AI Passport 发布流程的衔接](shinku-chen/post-release-follow-up.zh_CN.md) — 确认发布目的地、发布时包含数据分区、以及发布后收尾各轨道的同意门槛。
 - [ESP32-C3（无 PSRAM）上的显示刷新与深睡](shinku-chen/display-refresh-and-deep-sleep.zh_CN.md) — 直接刷新单个图片矩形、RTC GPIO 深睡唤醒，以及 LVGL 对象类型误用的崩溃特征。
+- [深睡前关闭板载外设](shinku-chen/deep-sleep-peripheral-power-off.zh_CN.md) — 深睡前把 LCD 面板、背光、codec、电量计下电，`esp_codec_dev_close()` 只在「打开过」才 suspend 的坑，以及软件修不了的部分（常通功放、稳压器）。
 
 **应用档案：**
 

--- a/docs/reference/shinku-chen/deep-sleep-peripheral-power-off.md
+++ b/docs/reference/shinku-chen/deep-sleep-peripheral-power-off.md
@@ -1,0 +1,90 @@
+<p align="right">
+  <a href="deep-sleep-peripheral-power-off.zh_CN.md">简体中文</a> · <strong>English</strong>
+</p>
+
+# Shutting Down On-Board Peripherals Before Deep-Sleep
+
+Captured after the **"Sound Effects Keychain"** v1.4.0 firmware release on the
+voice-keychain edition (commit `ce9b13d`). These are general, upstream-benefiting
+learnings that apply to any AI Passport app, not fork-specific customization.
+
+> **Verification status.** All of the following was verified on device with the
+> sound-keychain firmware: the device sleeps after 5 min idle and wakes on any
+> button, and codec/panel/gauge draw drops in deep sleep. Standby-current numbers
+> were not measured with a meter, so treat the magnitude claims as relative.
+
+## Why shut peripherals down at all
+
+`esp_deep_sleep_start()` powers the MCU core down, but the peripherals that sit on
+an always-on 3.3 V rail are **not** cut off — they keep drawing current even while
+the chip sleeps. If the intent is minimum standby draw, each shuttable peripheral
+must be told to enter its own low-power state before the chip sleeps. The MCU side
+is handled for you; the peripheral side is not.
+
+## The four shutdown calls, in order
+
+Call these **after** arming the GPIO wake source and **before**
+`esp_deep_sleep_start()`:
+
+| Peripheral | Function | What it does |
+|---|---|---|
+| LCD panel | `bsp_display_sleep()` | `esp_lcd_panel_disp_on_off(panel, false)` (0x28 DISPOFF) then `esp_lcd_panel_disp_sleep(panel, true)` (0x10 panel sleep). A black screen is **not** powered down — the panel's controller still draws even with the backlight off and DISP off. |
+| Backlight | `bsp_display_backlight(0)` | Set the LEDC duty to 0. Deep sleep also floats this un-held pin, so the LED is dark either way, but zeroing first is explicit. |
+| Audio codec | `bsp_audio_sleep()` | Close the codec, which runs `es8311_suspend()` — writes 16 registers to stop the ADC/DAC, gate the clock, and disable the PA. |
+| Fuel gauge | `bsp_battery_sleep()` | Put the CW2017 to sleep: write CONFIG 0x30 (restart) then 0xF0 (sleep). |
+
+## Gotcha: `esp_codec_dev_close()` only suspends if the codec layer was opened
+
+The trap that cost the most debugging. `esp_codec_dev_close()` calls
+`es8311_enable(false)` — which is what actually runs `es8311_suspend()` and powers
+the chip down — **only** when the codec-dev layer's `output_opened`/`input_opened`
+is true. Otherwise it falls straight through to cleanup and does nothing.
+
+Your own `s_opened` flag mirrors that: it is only true after a
+`bsp_audio_set_format()` succeeds. So if the device **never plays any audio before
+timing out into deep sleep**, `s_opened == false`, the close is skipped, and the
+chip sits in the `es8311_open` configuration state — configured but **not**
+powered down. The fix is to guarantee the suspend sequence runs on every path:
+
+```c
+esp_err_t bsp_audio_sleep(void) {
+    if (!s_dev) return ESP_ERR_INVALID_STATE;
+    if (!s_opened) {
+        bsp_audio_set_format(16000, 16, 1);   // silent open — no sound, just takes the codec-dev layer open
+    }
+    esp_codec_dev_close(s_dev);                 // now really runs es8311_suspend()
+    s_opened = false;
+    return ESP_OK;
+}
+```
+
+The added `set_format` is silent (it never writes PCM), only completes the
+codec-dev `open` path so the subsequent `close` triggers the suspend. A `s_dev`
+that exists but was never opened is exactly the case that silently leaked.
+
+## The MCU side is already handled — don't redo it
+
+`esp_deep_sleep_start()` automatically calls `esp_sleep_isolate_digital_gpio()`
+on this platform (ESP32-C3 does **not** define `SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP`,
+so the `#if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP` branch always runs). That
+floats every un-held digital GPIO — including the I2S, I2C, and SPI pins — and
+disables their internal pull-ups/pull-downs. So there is no MCU-side leakage path
+to chase; the residual draw is purely the peripherals on the rail (and, outside
+the chip, the external PA and the 3.3 V regulator, which are out of software reach).
+
+## What software cannot fix
+
+The board's power amplifier uses `BSP_I2S_PA_CTRL = -1`, meaning the PA enable pin
+is **not** wired to the MCU — it is hardware always-on. Powering it off requires a
+board change (wire the enable pin, or put the PA on a switchable rail). Similarly,
+the 3.3 V rail's own regulator quiescent current and cell self-discharge are not
+software-addressable. If standby is still high after all four calls, the remaining
+draw is almost certainly these hardware constants.
+
+## A real wake-from-sleep pitfall that overlaps this work
+
+While here, note the related wakeup gotcha recorded separately in
+[`display-refresh-and-deep-sleep.md`](display-refresh-and-deep-sleep.md): the
+wake-source argument is a **pin bitmask**, not a pin number. It is easy to re-verify
+both together — after these shutdown calls, wake on GPIO0 low and confirm the app
+re-initializes the peripherals it just shut down.

--- a/docs/reference/shinku-chen/deep-sleep-peripheral-power-off.zh_CN.md
+++ b/docs/reference/shinku-chen/deep-sleep-peripheral-power-off.zh_CN.md
@@ -1,0 +1,78 @@
+<p align="right">
+  <strong>简体中文</strong> · <a href="deep-sleep-peripheral-power-off.md">English</a>
+</p>
+
+# 深睡前关闭板载外设
+
+在「音效钥匙扣」v1.4.0 固件、voice-keychain 版本（提交 `ce9b13d`）发布后沉淀。
+这些是通用、上游受益的经验，适用于任何 AI Passport 应用，而非 fork 专属定制。
+
+> **验证状态。** 以下均已在本项目「音效钥匙扣」固件上真机验证：空闲 5 分钟入睡、
+> 任意按键可唤醒、codec/面板/电量计在深睡时电流下降。待机电流数值未用万用表实测，
+> 故“量级”描述请视为相对大小，不是确切读数。
+
+## 为什么要关外设
+
+`esp_deep_sleep_start()` 只把 MCU 核心断电，但挂在常通 3.3 V 轨上的**外设并不会**
+被切断——它们仍在耗电。若目标是极低待机，每个可关的外设都必须在芯片入睡前被
+点名进入自己的低功耗态。MCU 侧有框架代劳，外设侧没有。
+
+## 四条关机调用，按顺序
+
+在**配好 GPIO 唤醒源之后**、`esp_deep_sleep_start()` 之前调用这些：
+
+| 外设 | 函数 | 做了什么 |
+|---|---|---|
+| LCD 面板 | `bsp_display_sleep()` | `esp_lcd_panel_disp_on_off(panel, false)`（0x28 DISPOFF）再 `esp_lcd_panel_disp_sleep(panel, true)`（0x10 面板睡眠）。**黑屏并不等于下电**——就算背光灭、DISP 关，面板控制器仍在耗电。 |
+| 背光 | `bsp_display_backlight(0)` | 把 LEDC 占空比归零。深睡本就会把该未被 hold 的引脚浮空，LED 反正灭，但先归零更明确。 |
+| 音频 codec | `bsp_audio_sleep()` | 关闭 codec，内部走 `es8311_suspend()`——写 16 个寄存器停掉 ADC/DAC、门控时钟、禁用 PA。 |
+| 电量计 | `bsp_battery_sleep()` | 让 CW2017 进睡眠：写 CONFIG 0x30（重启）再 0xF0（睡眠）。 |
+
+## 坑：`esp_codec_dev_close()` 只在 codec 层「被打开过」时才真正 suspend
+
+最花调试时间的一个坑。真正执行 `es8311_suspend()`、把芯片下电的是
+`es8311_enable(false)`，而 `esp_codec_dev_close()` **只在** codec-dev 层的
+`output_opened`/`input_opened` 为 true 时才走到它；否则直接进 cleanup，什么都不做。
+
+你自己维护的 `s_opened` 正好镜像这一点：它只在 `bsp_audio_set_format()` 成功后
+才为 true。所以如果设备**开机后从未播放任何音频就超时深睡**，`s_opened == false`，
+close 被跳过，芯片停在 `es8311_open` 的配置态——配好寄存器了，但**没有下电**。
+修复是保证任何时序都走完 suspend 序列：
+
+```c
+esp_err_t bsp_audio_sleep(void) {
+    if (!s_dev) return ESP_ERR_INVALID_STATE;
+    if (!s_opened) {
+        bsp_audio_set_format(16000, 16, 1);   // 无声打开——不发声，只是把 codec-dev 层走成 open
+    }
+    esp_codec_dev_close(s_dev);                 // 这次才真的跑 es8311_suspend()
+    s_opened = false;
+    return ESP_OK;
+}
+```
+
+多出来的 `set_format` 是无声的（从不写 PCM），只是补完 codec-dev 的 `open` 路径，
+让随后的 `close` 真正触发 suspend。「`s_dev` 存在但从未 open 过」正是那个静默泄漏的场景。
+
+## MCU 侧已经代劳，无需再处理
+
+在此平台上 `esp_deep_sleep_start()` 会自动调用 `esp_sleep_isolate_digital_gpio()`
+（ESP32-C3 **未定义** `SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP`，
+所以 `#if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP` 分支一定会走）。它把每个
+未被 hold 的数字 GPIO——包括 I2S、I2C、SPI 引脚——全部浮空，并禁用其内部上/下拉。
+所以没有任何 MCU 侧漏电路径需要追；残余耗电纯粹来自轨上的外设（以及芯片之外、
+代码够不着的功放和 3.3 V 稳压器）。
+
+## 软件修不了的部分
+
+本板功放用 `BSP_I2S_PA_CTRL = -1`，即 PA 使能脚**没有接到 MCU**——硬件常通。
+要断它只能改板（接使能脚，或把功放放到可切换的电源轨上）。同理，3.3 V 轨稳压器
+自身的静态电流和电池自放电也不是软件能插手的。四条调用全上待机仍偏高时，剩下的
+大头几乎可以肯定是这些硬件常量。
+
+## 与本工作重叠的一个真实唤醒坑
+
+顺带一提，相关的唤醒坑已单独记录在
+[`display-refresh-and-deep-sleep.zh_CN.md`](display-refresh-and-deep-sleep.zh_CN.md)：
+唤醒源参数是**引脚位掩码**，不是引脚号。两者可以一起复核——跑完这些关机调用后，
+用 GPIO0 低电平唤醒，确认应用会重新初始化它刚关掉的外设。


### PR DESCRIPTION
## Summary

Adds a reusable, upstream-benefiting experience entry documenting how to shut
down the on-board peripherals before deep sleep on the AI Passport, captured
after the Sound Effects Keychain v1.4.0 release. This is documentation only; no
runtime behaviour changes.

The new entry (`docs/reference/shinku-chen/deep-sleep-peripheral-power-off.md`)
records four things that apply to any AI Passport app, not fork-specific tuning:

- **Why shut peripherals down at all**: `esp_deep_sleep_start()` powers the MCU
  core down but the peripherals on an always-on 3.3 V rail are not cut off.
- **The four shutdown calls** (LCD panel, backlight, audio codec, fuel gauge)
  with the exact driver calls, in the order to call them before sleeping.
- **The `esp_codec_dev_close()` trap**: it only runs `es8311_suspend()` when the
  codec-dev layer was opened, so if the device never plays audio before timing
  out into deep sleep, the chip sits in the `es8311_open` config state and is
  never truly powered down. Include the fix (silent `set_format` then close).
- **What software cannot fix**: the MCU side is already handled by
  `esp_sleep_isolate_digital_gpio()`, but the always-on PA (`pa_pin` = -1) and
  the 3.3 V regulator are hardware constants.

Bilingual `.md` / `.zh_CN.md` pair is added and indexed in
`docs/reference/README.md`.

## Scope and compatibility

- Affected board/revision: None (documentation only)
- Affected subsystem: Docs — `docs/reference/shinku-chen/`
- Wiring or pin-map impact: None
- Flash, partition, or persistent-data impact: None
- Backward-compatibility impact: None

## Verification

| Check | Result | Evidence or notes |
| --- | --- | --- |
| Build | NOT RUN | Documentation-only change; no code touched |
| Host tests | NOT RUN | Documentation-only change |
| Device tests | PASS | The described shutdown was verified on the sound-keychain firmware (see the entry's verification note) |
| Unverified | — | None; standby-current magnitudes were observed but not metered |

## Checklist

- [x] I reviewed the complete diff and excluded unrelated/generated files.
- [x] I ran the relevant validation command or explained why it was not run.
- [x] I separated build, host-test, and device-test results.
