### PR TITLE
docs(readme): remove duplicate community links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,4 @@ Repository documentation is organized by function area. `authoritative` document
 
 GitHub community documents: [CONTRIBUTING.md](../.github/CONTRIBUTING.md), [CODE_OF_CONDUCT.md](../.github/CODE_OF_CONDUCT.md), [SECURITY.md](../.github/SECURITY.md), and [SUPPORT.md](../.github/SUPPORT.md).
 
-GitHub community documents: [CONTRIBUTING.md](../.github/CONTRIBUTING.md), [CODE_OF_CONDUCT.md](../.github/CODE_OF_CONDUCT.md), [SECURITY.md](../.github/SECURITY.md), and [SUPPORT.md](../.github/SUPPORT.md).
-
 > This README describes the product and repository. AI agents must begin with `AGENTS.md` and follow its task-specific routing.


### PR DESCRIPTION
## Summary

Remove the duplicate “GitHub community documents” paragraph from `docs/README.md`. Keep one copy of the links, matching the existing Chinese README.

## Scope and compatibility

- Affected board/revision: None
- Affected subsystem: English repository overview
- Wiring or pin-map impact: None
- Flash, partition, or persistent-data impact: None
- Backward-compatibility impact: None

## Verification

| Check | Result | Evidence or notes |
| --- | --- | --- |
| Build | NOT RUN | Documentation-only deletion; no firmware change |
| Host tests | PASS | Static validation, repository checks and host tests |
| Device tests | NOT RUN | No hardware-facing changes |
| Unverified | — | Firmware and device checks not applicable to this text-only fix |

Commands run:

```text
ACTIONLINT_BIN=/tmp/actionlint-1.7.12/actionlint ./tools/validate.sh --static
git diff --check
```

## Device evidence

Not applicable: this PR only removes a duplicated paragraph. The Chinese README already contains one copy and needs no change.

## Checklist

- [x] I reviewed the complete diff and excluded unrelated/generated files.
- [x] I ran the relevant validation command or explained why it was not run.
- [x] I separated build, host-test, and device-test results.
- [x] I updated authoritative documentation for changed hardware facts or durable behavior (not applicable).
- [x] I updated `docs/CHANGELOG.md` if this changes user-visible behavior, compatibility, or release workflow (not required for duplicate-text cleanup).
- [x] I removed credentials, private device links, personal data, and unsanitized logs.
