### PR TITLE
feat(tasks): add Cindy task bridge demo with voice feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/
+__pycache__/
+main/app_config.h
 sdkconfig
 sdkconfig.old
 managed_components/

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,33 @@
+<p align="right">
+  <strong>English</strong> · <a href="README.zh_CN.md">简体中文</a>
+</p>
+
+# Cindy Task Bridge
+
+A zero-dependency local HTTP service that connects the AI Passport device to task state on your computer.
+
+## Protocol
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/tasks` | Returns `{"tasks": [...]}` read fresh from `bridge/tasks.json` on every request, so any writer can update it between polls. |
+| GET | `/health` | Liveness check. |
+| POST | `/feedback?task_id=<id>&hz=16000&bits=16&ch=1` | Body is raw little-endian PCM. The server wraps it into a WAV file under `bridge/feedback/<task_id>/` and appends a line to `bridge/feedback/log.jsonl`. |
+
+Task fields consumed by the device: `id` (required, unique), `title`, `status` (`queued` / `running` / `in_progress` / `done` / `completed` / `failed` / `error`), `message`, `updated_at` (epoch seconds). At most 8 tasks are shown.
+
+## Run
+
+`bash
+python3 bridge/server.py --port 8787
+`
+
+## Feed task data
+
+`tasks.json` is the single integration point. Any process on this computer can rewrite it between polls: a Cindy session, a cron job, or a manual edit all work. Keep task messages ASCII/Latin where possible, because the device font has no CJK glyphs.
+
+## Device setup
+
+1. Copy `main/app_config.h.example` to `main/app_config.h` (gitignored).
+2. Fill `APP_WIFI_SSID`, `APP_WIFI_PASSWORD` (2.4 GHz), and `APP_BRIDGE_URL` with this computer LAN address, for example `http://192.168.1.20:8787`.
+3. Build and flash per `docs/development/engineering/build-and-test.md`, then open the Tasks page in the device menu.

--- a/bridge/README.zh_CN.md
+++ b/bridge/README.zh_CN.md
@@ -1,0 +1,33 @@
+<p align="right">
+  <a href="README.md">English</a> · <strong>简体中文</strong>
+</p>
+
+# Cindy 任务桥
+
+零依赖的本地 HTTP 服务，把 AI Passport 设备和电脑上的任务状态连起来。
+
+## 协议
+
+| 方法 | 路径 | 用途 |
+| --- | --- | --- |
+| GET | `/tasks` | 每次请求都重新读取 `bridge/tasks.json` 并返回 `{"tasks": [...]}`，任何进程都可以在两次轮询之间改写它。 |
+| GET | `/health` | 存活检查。 |
+| POST | `/feedback?task_id=<id>&hz=16000&bits=16&ch=1` | 请求体为原始小端 PCM。服务端包装成 WAV 存到 `bridge/feedback/<task_id>/`，并在 `bridge/feedback/log.jsonl` 追加一行记录。 |
+
+设备消费的任务字段：`id`（必填且唯一）、`title`、`status`（`queued` / `running` / `in_progress` / `done` / `completed` / `failed` / `error`）、`message`、`updated_at`（epoch 秒）。设备最多展示 8 条。
+
+## 运行
+
+`bash
+python3 bridge/server.py --port 8787
+`
+
+## 喂任务数据
+
+`tasks.json` 是唯一接入点。Cindy 会话、定时脚本或手工编辑都可以在轮询之间改写这个文件。任务消息尽量用 ASCII/拉丁字符：设备字体没有中文字形。
+
+## 设备配置
+
+1. 复制 `main/app_config.h.example` 为 `main/app_config.h`（已被 gitignore）。
+2. 填写 `APP_WIFI_SSID`、`APP_WIFI_PASSWORD`（2.4GHz）和 `APP_BRIDGE_URL`（本电脑局域网地址，例如 `http://192.168.1.20:8787`）。
+3. 按 `docs/development/engineering/build-and-test.md` 构建烧录，在设备菜单里打开 Tasks 页面。

--- a/bridge/server.py
+++ b/bridge/server.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Local task bridge for FoloToy AI Passport.
+
+GET  /tasks    -> serves bridge/tasks.json (read fresh on every request)
+GET  /health   -> {"ok": true}
+POST /feedback?task_id=..&hz=..&bits=..&ch=..  (raw PCM body)
+               -> wraps the body into a WAV file under bridge/feedback/<task_id>/
+
+Standard library only. Run: python3 bridge/server.py --port 8787
+"""
+
+import argparse
+import json
+import time
+import wave
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, unquote, urlparse
+
+ROOT = Path(__file__).resolve().parent
+FEEDBACK_DIR = ROOT / "feedback"
+
+
+def sanitize(name: str) -> str:
+    cleaned = "".join(c if c.isalnum() or c in "-_." else "_" for c in name)
+    return cleaned[:64] or "unknown"
+
+
+class BridgeHandler(BaseHTTPRequestHandler):
+    def send_json(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+        if path == "/health":
+            return self.send_json(200, {"ok": True})
+        if path == "/tasks":
+            source = ROOT / "tasks.json"
+            try:
+                data = json.loads(source.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                return self.send_json(200, {"tasks": []})
+            except ValueError as exc:
+                return self.send_json(500, {"error": f"invalid tasks.json: {exc}"})
+            if isinstance(data, dict):
+                tasks = data.get("tasks", [])
+            else:
+                tasks = data
+            return self.send_json(200, {"tasks": tasks})
+        return self.send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        query = parse_qs(urlparse(self.path).query)
+        task_id = sanitize(unquote(query.get("task_id", ["unknown"])[0]))
+        hz = int(query.get("hz", ["16000"])[0])
+        bits = int(query.get("bits", ["16"])[0])
+        channels = int(query.get("ch", ["1"])[0])
+        length = int(self.headers.get("Content-Length", 0))
+        if length <= 0:
+            return self.send_json(400, {"error": "empty body"})
+
+        pcm = self.rfile.read(length)
+        out_dir = FEEDBACK_DIR / task_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        wav_path = out_dir / f"{stamp}.wav"
+        with wave.open(str(wav_path), "wb") as wav:
+            wav.setnchannels(channels)
+            wav.setsampwidth(bits // 8)
+            wav.setframerate(hz)
+            wav.writeframes(pcm)
+
+        entry = {
+            "time": stamp,
+            "task_id": task_id,
+            "file": str(wav_path.relative_to(ROOT)),
+            "bytes": length,
+            "hz": hz,
+        }
+        with (FEEDBACK_DIR / "log.jsonl").open("a", encoding="utf-8") as log:
+            log.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        print(f"[feedback] task={task_id} <- {wav_path.name} ({length} bytes, {hz}Hz)")
+        self.send_json(200, {"ok": True, "file": entry["file"]})
+
+    def log_message(self, fmt: str, *args) -> None:
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8787)
+    args = parser.parse_args()
+    FEEDBACK_DIR.mkdir(exist_ok=True)
+    server = ThreadingHTTPServer((args.host, args.port), BridgeHandler)
+    print(f"bridge listening on {args.host}:{args.port}; tasks from {ROOT / 'tasks.json'}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge/tasks.json
+++ b/bridge/tasks.json
@@ -1,0 +1,25 @@
+{
+  "tasks": [
+    {
+      "id": "t-101",
+      "title": "Prepare review notes",
+      "status": "running",
+      "message": "Generating section summaries (3/5)",
+      "updated_at": 1757418000
+    },
+    {
+      "id": "t-102",
+      "title": "Fix login timeout",
+      "status": "done",
+      "message": "PR merged, build green",
+      "updated_at": 1757415000
+    },
+    {
+      "id": "t-103",
+      "title": "Collect benchmark data",
+      "status": "queued",
+      "message": "Waiting for upstream dataset",
+      "updated_at": 1757412000
+    }
+  ]
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 
+- Added the Cindy task bridge demo: a Tasks menu page with Wi-Fi STA connection (credentials in a gitignored main/app_config.h), 3-second polling of a local bridge server for up to 8 tasks with status chips and latest-message previews, a task detail view, and hold-to-record 16 kHz mono PCM feedback submitted over HTTP; added the dependency-free bridge/server.py that serves tasks.json and archives recordings as WAV files, plus host tests for the task list model.
 - Added the supplied 80-byte CW2017 profile for the specified 520 mAh cell, including content/update-flag checks, verified writes, the required restart sequence, and bounded SOC-readiness polling.
 
 - Expanded the environment bootstrap document: added Espressif's Git service mirror (`git.espressif.com.cn`) as the preferred mainland-China route for ESP-IDF v5.5.3 and its submodules, documented submodule long-wait/timeout handling, in-place repair, and the pinned-commit shallow fetch for large submodules such as `esp32-wifi-lib`, warned about stale per-repository Jihulab `insteadOf` residue, and added the official offline release archive as a last-resort fallback (learned from `esp-mosaico/esp-mosaico-vibe`).

--- a/docs/CHANGELOG.zh_CN.md
+++ b/docs/CHANGELOG.zh_CN.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 
+- 新增 Cindy 任务桥演示：Tasks 菜单页支持 Wi-Fi STA 连接（凭证放在 gitignore 的 main/app_config.h），每 3 秒轮询本地桥接服务获取最多 8 条任务的状态角标与最新消息预览，提供任务详情页，并可按键录制 16kHz 单声道 PCM 反馈经 HTTP 提交；新增零依赖的 bridge/server.py，负责提供 tasks.json 并把录音归档为 WAV 文件，同时为任务列表模型补充 host tests。
 - 加入厂家为优特利 520mAh 电芯生成的 80 字节 CW2017 profile，并实现内容与更新标志检查、写入后校验、规定的重启时序以及有上限的 SOC 就绪等待。
 
 - 扩充环境引导文档：新增乐鑫 Git 服务镜像（`git.espressif.com.cn`）作为中国大陆首选线路，覆盖 ESP-IDF v5.5.3 及其子模块；补充子模块长等待/超时处理、原地修复，以及 `esp32-wifi-lib` 等大仓的按钉死 commit 浅取；提示按仓库残留的 Jihulab `insteadOf` 旧配置；并把官方离线 release 压缩包加入兜底方案（经验来自 `esp-mosaico/esp-mosaico-vibe`）。

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -10,6 +10,10 @@ idf_component_register(
          "demo_wifi.c"
          "demo_ble.c"
          "demo_low_power.c"
+         "app_wifi.c"
+         "tasks_model.c"
+         "tasks_client.c"
+         "demo_tasks.c"
     INCLUDE_DIRS "."
-    REQUIRES bsp bt esp_event esp_hw_support esp_netif esp_timer esp_wifi nvs_flash
+    REQUIRES bsp bt esp_event esp_hw_support esp_http_client esp_netif esp_timer esp_wifi json nvs_flash
 )

--- a/main/app_config.h.example
+++ b/main/app_config.h.example
@@ -1,0 +1,9 @@
+// 复制本文件为 main/app_config.h 并填写真实值；main/app_config.h 已被 .gitignore 忽略。
+#pragma once
+
+// 2.4GHz Wi-Fi，设备与电脑须在同一局域网。
+#define APP_WIFI_SSID       "your-ssid"
+#define APP_WIFI_PASSWORD   "your-password"
+
+// 电脑上 bridge/server.py 的监听地址。
+#define APP_BRIDGE_URL      "http://192.168.1.100:8787"

--- a/main/app_config_loader.h
+++ b/main/app_config_loader.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// 本地配置（Wi-Fi 凭证、bridge 地址）。不入库；缺失时给出可操作的编译错误。
+#if __has_include("app_config.h")
+#include "app_config.h"
+#else
+#error "复制 main/app_config.h.example 为 main/app_config.h，填写 Wi-Fi 与 APP_BRIDGE_URL"
+#endif

--- a/main/app_wifi.c
+++ b/main/app_wifi.c
@@ -1,0 +1,79 @@
+#include "app_wifi.h"
+
+#include "app_config_loader.h"
+#include "demo_radio.h"
+
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+
+#define WIFI_CONNECTED_BIT BIT0
+
+static const char *TAG = "app_wifi";
+
+static EventGroupHandle_t s_events;
+static bool s_started;
+
+static void on_event(void *arg, esp_event_base_t base, int32_t id, void *data) {
+    (void)arg; (void)data;
+    if (base == WIFI_EVENT && id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (base == WIFI_EVENT && id == WIFI_EVENT_STA_DISCONNECTED) {
+        xEventGroupClearBits(s_events, WIFI_CONNECTED_BIT);
+        esp_wifi_connect();
+    } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
+        xEventGroupSetBits(s_events, WIFI_CONNECTED_BIT);
+    }
+}
+
+esp_err_t app_wifi_start(void) {
+    if (s_started) return ESP_OK;
+
+    esp_err_t err = demo_radio_nvs_prepare();
+    if (err != ESP_OK) return err;
+    err = demo_radio_network_prepare();
+    if (err != ESP_OK) return err;
+
+    s_events = xEventGroupCreate();
+    if (!s_events) return ESP_ERR_NO_MEM;
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    err = esp_wifi_init(&cfg);
+    if (err != ESP_OK) return err;
+
+    err = esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, on_event, NULL, NULL);
+    if (err != ESP_OK) return err;
+    err = esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP, on_event, NULL, NULL);
+    if (err != ESP_OK) return err;
+
+    err = esp_wifi_set_storage(WIFI_STORAGE_RAM);
+    if (err != ESP_OK) return err;
+    err = esp_wifi_set_mode(WIFI_MODE_STA);
+    if (err != ESP_OK) return err;
+
+    wifi_config_t wifi_cfg = { 0 };
+    strncpy((char *)wifi_cfg.sta.ssid, APP_WIFI_SSID, sizeof(wifi_cfg.sta.ssid) - 1);
+    strncpy((char *)wifi_cfg.sta.password, APP_WIFI_PASSWORD, sizeof(wifi_cfg.sta.password) - 1);
+    err = esp_wifi_set_config(WIFI_IF_STA, &wifi_cfg);
+    if (err != ESP_OK) return err;
+
+    err = esp_wifi_start();
+    if (err != ESP_OK) return err;
+
+    s_started = true;
+    ESP_LOGI(TAG, "STA 连接中: %s", APP_WIFI_SSID);
+    return ESP_OK;
+}
+
+bool app_wifi_wait(size_t timeout_ms) {
+    if (!s_started) return false;
+    EventBits_t bits = xEventGroupWaitBits(s_events, WIFI_CONNECTED_BIT,
+                                           pdFALSE, pdFALSE, pdMS_TO_TICKS(timeout_ms));
+    return (bits & WIFI_CONNECTED_BIT) != 0;
+}
+
+bool app_wifi_is_connected(void) {
+    return s_events && (xEventGroupGetBits(s_events) & WIFI_CONNECTED_BIT) != 0;
+}

--- a/main/app_wifi.h
+++ b/main/app_wifi.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include "esp_err.h"
+
+// STA 连接的公共入口：幂等，首次调用时初始化 NVS/netif/事件循环并启动连接。
+// 失败不重试连接；断线后由事件回调自动重连。
+esp_err_t app_wifi_start(void);
+
+// 等待拿到 IP。超时返回 false。
+bool app_wifi_wait(size_t timeout_ms);
+
+bool app_wifi_is_connected(void);

--- a/main/demo.h
+++ b/main/demo.h
@@ -32,3 +32,6 @@ void demo_ble_key(bsp_btn_t btn, bsp_btn_ev_t ev);
 
 void demo_low_power_enter(void); void demo_low_power_exit(void);
 void demo_low_power_key(bsp_btn_t btn, bsp_btn_ev_t ev);
+
+void demo_tasks_enter(void);   void demo_tasks_exit(void);
+void demo_tasks_key(bsp_btn_t btn, bsp_btn_ev_t ev);

--- a/main/demo_tasks.c
+++ b/main/demo_tasks.c
@@ -1,0 +1,371 @@
+// main/demo_tasks.c —— Cindy 任务面板：列表 / 详情 / 录音三视图 + 轮询与录音工作任务。
+//
+// 按键(页面内)：UP/DOWN 移动选中或切换任务；OK 短按 进详情 / 开始录音 / 停止并发送；
+// OK 长按由 main.c 统一返回菜单，录音中返回即放弃本次录音。
+// 录音为 16kHz/16bit/mono PCM，按剩余最大连续堆自动限长(最长 6s)，直接 POST 给 bridge。
+// 屏幕字体不含中文字形，界面文案一律英文。
+#include "demo.h"
+#include "app_wifi.h"
+#include "tasks_client.h"
+#include "tasks_model.h"
+#include "ui_pixel.h"
+
+#include "bsp_audio.h"
+#include "bsp_display.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "lvgl.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define REC_HZ          16000
+#define REC_BPS         (REC_HZ * 2)                 // 16bit mono = 32KB/s
+#define REC_MAX_BYTES   (6 * REC_BPS)
+#define POLL_PERIOD_MS  3000
+#define WORKER_TICK_MS  150
+
+typedef enum { VIEW_LIST = 0, VIEW_DETAIL, VIEW_RECORD } view_t;
+typedef enum { CMD_NONE = 0, CMD_RECORD, CMD_STOP_SEND } cmd_t;
+
+static const char *TAG = "demo_tasks";
+
+static TaskHandle_t s_worker;
+static volatile bool s_exit;
+static volatile cmd_t s_cmd;
+static volatile bool s_recording;
+
+static tasks_model_t s_model;
+static view_t s_view;
+static char s_line[96];                 // 屏幕右上角状态行（IP / 错误）
+
+static lv_obj_t *s_scr;
+static lv_obj_t *s_line_label;
+static lv_obj_t *s_box_list, *s_box_detail, *s_box_record;
+static lv_obj_t *s_cards[TASKS_MODEL_MAX];
+static lv_obj_t *s_rec_sec, *s_rec_bar, *s_rec_hint;
+
+static const uint32_t CHIP_COLORS[] = {
+    [TASK_CHIP_QUEUED]  = 0x78909C,
+    [TASK_CHIP_RUNNING] = UI_YELLOW,
+    [TASK_CHIP_DONE]    = UI_GRASS,
+    [TASK_CHIP_FAILED]  = UI_RED,
+    [TASK_CHIP_UNKNOWN] = 0x78909C,
+};
+
+static lv_obj_t *make_box(lv_obj_t *parent, int y) {
+    lv_obj_t *box = lv_obj_create(parent);
+    lv_obj_remove_flag(box, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_pos(box, 0, y);
+    lv_obj_set_size(box, 240, 320 - y);
+    lv_obj_set_style_bg_opa(box, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(box, 0, 0);
+    lv_obj_set_style_pad_all(box, 0, 0);
+    return box;
+}
+
+static void view_show(view_t v) {
+    lv_obj_add_flag(s_box_list, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(s_box_detail, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(s_box_record, LV_OBJ_FLAG_HIDDEN);
+    s_view = v;
+    lv_obj_t *target = v == VIEW_LIST ? s_box_list
+                     : v == VIEW_DETAIL ? s_box_detail : s_box_record;
+    lv_obj_remove_flag(target, LV_OBJ_FLAG_HIDDEN);
+}
+
+static void list_highlight(void) {
+    for (int i = 0; i < s_model.count; i++) {
+        if (s_cards[i]) ui_pixel_set_selected(s_cards[i], i == s_model.selected, true);
+    }
+    if (s_model.count > 0 && s_cards[s_model.selected]) {
+        lv_obj_scroll_to_view(s_cards[s_model.selected], LV_ANIM_OFF);
+    }
+}
+
+static void list_rebuild(void) {
+    lv_obj_clean(s_box_list);
+    for (int i = 0; i < TASKS_MODEL_MAX; i++) s_cards[i] = NULL;
+
+    if (s_model.count == 0) {
+        lv_obj_t *empty = ui_pixel_label(s_box_list, "No tasks yet",
+                                         &lv_font_montserrat_14, 0x5A6B7A);
+        lv_obj_center(empty);
+        return;
+    }
+    for (int i = 0; i < s_model.count; i++) {
+        const task_item_t *it = &s_model.items[i];
+        lv_obj_t *card = ui_pixel_panel_create(s_box_list, 12, 6 + i * 60, 216, 54, UI_PAPER);
+
+        lv_obj_t *title = ui_pixel_label(card, it->title, &lv_font_montserrat_14, UI_INK);
+        lv_obj_set_width(title, 128);
+        lv_label_set_long_mode(title, LV_LABEL_LONG_DOT);
+        lv_obj_align(title, LV_ALIGN_TOP_LEFT, 0, 0);
+
+        lv_obj_t *badge = ui_pixel_label(card, it->status,
+                                         &lv_font_montserrat_14, CHIP_COLORS[tasks_model_chip(it->status)]);
+        lv_obj_align(badge, LV_ALIGN_TOP_RIGHT, 0, 0);
+
+        char prev[64];
+        tasks_model_preview(it->message, prev, sizeof(prev));
+        lv_obj_t *msg = ui_pixel_label(card, prev, &lv_font_montserrat_14, 0x5A6B7A);
+        lv_obj_set_width(msg, 200);
+        lv_label_set_long_mode(msg, LV_LABEL_LONG_DOT);
+        lv_obj_align(msg, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+
+        s_cards[i] = card;
+    }
+    list_highlight();
+}
+
+static void detail_show(void) {
+    const task_item_t *it = tasks_model_current(&s_model);
+    if (!it) { view_show(VIEW_LIST); return; }
+
+    lv_obj_clean(s_box_detail);
+    lv_obj_t *panel = ui_pixel_panel_create(s_box_detail, 12, 6, 216, 214, UI_PAPER);
+
+    lv_obj_t *title = ui_pixel_label(panel, it->title, &lv_font_montserrat_14, UI_INK);
+    lv_obj_set_width(title, 190);
+    lv_label_set_long_mode(title, LV_LABEL_LONG_DOT);
+    lv_obj_align(title, LV_ALIGN_TOP_LEFT, 0, 0);
+
+    lv_obj_t *status = ui_pixel_label(panel, it->status,
+                                      &lv_font_montserrat_14, CHIP_COLORS[tasks_model_chip(it->status)]);
+    lv_obj_align(status, LV_ALIGN_TOP_RIGHT, 0, 0);
+
+    lv_obj_t *msg = ui_pixel_label(panel, it->message, &lv_font_montserrat_14, 0x3A4A5A);
+    lv_obj_set_width(msg, 190);
+    lv_label_set_long_mode(msg, LV_LABEL_LONG_WRAP);
+    lv_obj_align(msg, LV_ALIGN_TOP_LEFT, 0, 26);
+
+    lv_obj_t *hint = ui_pixel_label(panel, "OK: record  U/D: switch",
+                                    &lv_font_montserrat_14, UI_SKY_DARK);
+    lv_obj_align(hint, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+    view_show(VIEW_DETAIL);
+}
+
+static void record_show(void) {
+    lv_obj_clean(s_box_record);
+    s_rec_sec = ui_pixel_label(s_box_record, "0s", &lv_font_montserrat_20, UI_INK);
+    lv_obj_align(s_rec_sec, LV_ALIGN_TOP_MID, 0, 40);
+
+    s_rec_bar = lv_bar_create(s_box_record);
+    lv_obj_set_size(s_rec_bar, 200, 14);
+    lv_obj_align(s_rec_bar, LV_ALIGN_TOP_MID, 0, 90);
+    lv_bar_set_range(s_rec_bar, 0, 100);
+
+    s_rec_hint = ui_pixel_label(s_box_record, "OK: stop & send", &lv_font_montserrat_14, UI_SKY_DARK);
+    lv_obj_align(s_rec_hint, LV_ALIGN_TOP_MID, 0, 140);
+    view_show(VIEW_RECORD);
+}
+
+static void status_refresh(void) {
+    if (s_line_label) lv_label_set_text(s_line_label, s_line);
+}
+
+static void ip_text(char *out, size_t cap) {
+    esp_netif_t *netif = esp_netif_get_default_netif();
+    esp_netif_ip_info_t info;
+    if (!netif || esp_netif_get_ip_info(netif, &info) != ESP_OK || info.ip.addr == 0) {
+        snprintf(out, cap, "Wi-Fi...");
+        return;
+    }
+    snprintf(out, cap, "WiFi " IPSTR, IP2STR(&info.ip));
+}
+
+static void do_poll(void) {
+    task_item_t items[TASKS_MODEL_MAX];
+    int count = 0;
+    esp_err_t err = tasks_client_fetch(items, TASKS_MODEL_MAX, &count);
+    if (!bsp_lvgl_lock(800)) return;
+    if (s_exit || !s_box_list) {
+        bsp_lvgl_unlock();
+        return;
+    }
+
+    if (err == ESP_OK) {
+        char ip[32];
+        ip_text(ip, sizeof(ip));
+        snprintf(s_line, sizeof(s_line), "%s  tasks:%d", ip, count);
+        if (tasks_model_set_items(&s_model, items, count)) list_rebuild();
+    } else {
+        snprintf(s_line, sizeof(s_line), "bridge unreachable");
+    }
+    status_refresh();
+    bsp_lvgl_unlock();
+}
+
+static size_t rec_cap(void) {
+    size_t room = esp_heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+    if (room >= REC_MAX_BYTES + 64 * 1024) return REC_MAX_BYTES;
+    if (room >= 4 * REC_BPS + 64 * 1024) return 4 * REC_BPS;
+    if (room >= 2 * REC_BPS + 48 * 1024) return 2 * REC_BPS;
+    return 0;
+}
+
+static void do_record(void) {
+    size_t cap = rec_cap();
+    char task_id[TASK_ID_LEN] = "";
+    if (!bsp_lvgl_lock(800)) { s_cmd = CMD_NONE; return; }
+    const task_item_t *it = tasks_model_current(&s_model);
+    if (it) strncpy(task_id, it->id, sizeof(task_id) - 1);
+    if (cap == 0 || task_id[0] == 0) {
+        snprintf(s_line, sizeof(s_line), cap == 0 ? "low memory for record" : "no task selected");
+        status_refresh();
+        bsp_lvgl_unlock();
+        s_cmd = CMD_NONE;
+        return;
+    }
+    record_show();
+    bsp_lvgl_unlock();
+
+    uint8_t *buf = malloc(cap);
+    if (!buf) { s_cmd = CMD_NONE; return; }
+    if (bsp_audio_set_format(REC_HZ, 16, 1) != ESP_OK) {
+        free(buf);
+        s_cmd = CMD_NONE;
+        if (bsp_lvgl_lock(500)) { snprintf(s_line, sizeof(s_line), "audio unavailable"); status_refresh(); bsp_lvgl_unlock(); }
+        return;
+    }
+
+    s_recording = true;
+    int fill = 0;
+    int16_t chunk[256];                     // 512B = 16ms，短读让停止按键及时生效
+    int ui_skip = 0;
+    while (!s_exit && s_cmd == CMD_RECORD && fill < (int)cap) {
+        if (bsp_audio_read(chunk, sizeof(chunk)) != ESP_OK) break;
+        int peak = 0;
+        for (size_t i = 0; i < sizeof(chunk) / sizeof(chunk[0]); i++) {
+            int v = chunk[i] < 0 ? -chunk[i] : chunk[i];
+            if (v > peak) peak = v;
+        }
+        memcpy(buf + fill, chunk, sizeof(chunk));
+        fill += sizeof(chunk);
+        if (++ui_skip >= 3 && bsp_lvgl_lock(200)) {     // ~50ms 刷新一次，控制锁竞争
+            ui_skip = 0;
+            int level = peak * 100 / 32768;
+            lv_bar_set_value(s_rec_bar, level > 100 ? 100 : level, LV_ANIM_OFF);
+            lv_label_set_text_fmt(s_rec_sec, "%ds / %ds", fill / REC_BPS, (int)(cap / REC_BPS));
+            bsp_lvgl_unlock();
+        }
+    }
+    bool submit = !s_exit && s_cmd == CMD_STOP_SEND && fill > 0;
+    s_cmd = CMD_NONE;
+    s_recording = false;
+
+    if (submit) {
+        if (bsp_lvgl_lock(500)) { lv_label_set_text(s_rec_hint, "Sending..."); bsp_lvgl_unlock(); }
+        esp_err_t serr = tasks_client_post_feedback(task_id, buf, fill, REC_HZ);
+        if (bsp_lvgl_lock(500)) {
+            lv_label_set_text(s_rec_hint, serr == ESP_OK ? "Submitted" : "Send failed");
+            bsp_lvgl_unlock();
+        }
+        vTaskDelay(pdMS_TO_TICKS(900));
+    }
+    free(buf);
+    if (!s_exit && bsp_lvgl_lock(500)) {
+        detail_show();
+        bsp_lvgl_unlock();
+    }
+}
+
+static void worker_task(void *arg) {
+    (void)arg;
+    int64_t last_poll = 0;
+    esp_err_t werr = app_wifi_start();
+    if (werr != ESP_OK) ESP_LOGE(TAG, "wifi start: %s", esp_err_to_name(werr));
+
+    while (!s_exit) {
+        if (s_cmd == CMD_RECORD) {
+            do_record();
+        } else if (!s_recording) {
+            int64_t now = esp_timer_get_time() / 1000;
+            if (now - last_poll >= POLL_PERIOD_MS) {
+                last_poll = now;
+                if (app_wifi_is_connected()) {
+                    do_poll();
+                } else if (bsp_lvgl_lock(200)) {
+                    ip_text(s_line, sizeof(s_line));
+                    status_refresh();
+                    bsp_lvgl_unlock();
+                }
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(WORKER_TICK_MS));
+    }
+    s_worker = NULL;
+    vTaskDelete(NULL);
+}
+
+void demo_tasks_enter(void) {
+    tasks_model_init(&s_model);
+    s_exit = false;
+    s_cmd = CMD_NONE;
+    s_recording = false;
+    s_view = VIEW_LIST;
+    snprintf(s_line, sizeof(s_line), "Wi-Fi...");
+
+    s_scr = ui_pixel_screen_create("CINDY");
+    s_line_label = ui_pixel_label(s_scr, s_line, &lv_font_montserrat_14, UI_SKY_DARK);
+    lv_obj_align(s_line_label, LV_ALIGN_TOP_RIGHT, -8, 46);
+
+    s_box_list = make_box(s_scr, 68);
+    s_box_detail = make_box(s_scr, 68);
+    s_box_record = make_box(s_scr, 68);
+    lv_obj_add_flag(s_box_detail, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(s_box_record, LV_OBJ_FLAG_HIDDEN);
+
+    list_rebuild();
+
+    if (xTaskCreate(worker_task, "tasks_work", 8192, NULL, 5, &s_worker) != pdPASS) {
+        s_worker = NULL;
+        ESP_LOGE(TAG, "worker task create failed");
+    }
+    lv_screen_load(s_scr);
+}
+
+void demo_tasks_exit(void) {
+    s_exit = true;
+    int waited = 0;
+    while (s_worker && waited < 4000) {
+        bsp_lvgl_unlock();                  // 放锁让 worker 完成最后的 UI 清理
+        vTaskDelay(pdMS_TO_TICKS(20));
+        waited += 20;
+        while (!bsp_lvgl_lock(100)) vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    s_scr = NULL;
+    s_line_label = NULL;
+    s_box_list = s_box_detail = s_box_record = NULL;
+    s_rec_sec = s_rec_bar = s_rec_hint = NULL;
+    for (int i = 0; i < TASKS_MODEL_MAX; i++) s_cards[i] = NULL;
+}
+
+void demo_tasks_key(bsp_btn_t btn, bsp_btn_ev_t ev) {
+    if (!bsp_lvgl_lock(500)) return;
+    if (ev == BSP_BTN_CLICK && !s_recording) {
+        int delta = btn == BSP_BTN_UP ? -1 : 1;
+        if (btn == BSP_BTN_UP || btn == BSP_BTN_DOWN) {
+            if (s_view == VIEW_LIST) {
+                tasks_model_move(&s_model, delta);
+                list_highlight();
+            } else if (s_view == VIEW_DETAIL) {
+                tasks_model_move(&s_model, delta);
+                detail_show();
+            }
+        } else if (btn == BSP_BTN_OK) {
+            if (s_view == VIEW_LIST && s_model.count > 0) {
+                detail_show();
+            } else if (s_view == VIEW_DETAIL) {
+                s_cmd = CMD_RECORD;
+            } else if (s_view == VIEW_RECORD && s_cmd == CMD_RECORD) {
+                s_cmd = CMD_STOP_SEND;
+            }
+        }
+    }
+    bsp_lvgl_unlock();
+}

--- a/main/main.c
+++ b/main/main.c
@@ -26,6 +26,7 @@ static const demo_entry_t DEMOS[] = {
     { "Wi-Fi",   demo_wifi_enter,    demo_wifi_exit,    demo_wifi_key    },
     { "BLE",     demo_ble_enter,     demo_ble_exit,     demo_ble_key     },
     { "Low Power", demo_low_power_enter, demo_low_power_exit, demo_low_power_key },
+    { "Tasks",   demo_tasks_enter,   demo_tasks_exit,   demo_tasks_key   },
 };
 #define DEMO_COUNT (sizeof(DEMOS) / sizeof(DEMOS[0]))
 
@@ -131,6 +132,7 @@ void app_main(void) {
     s_ok[4] = true;                                    // 页面内按需初始化并显示错误
     s_ok[5] = true;
     s_ok[6] = true;
+    s_ok[7] = true;                                    // Tasks: 页面内连接 Wi-Fi 并显示错误
 
     if (bsp_lvgl_lock(1000)) { enter_menu(); bsp_lvgl_unlock(); }
 

--- a/main/tasks_client.c
+++ b/main/tasks_client.c
@@ -1,0 +1,131 @@
+#include "tasks_client.h"
+
+#include "app_config_loader.h"
+#include "tasks_model.h"
+
+#include "cJSON.h"
+#include "esp_http_client.h"
+#include "esp_log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *TAG = "tasks_client";
+
+static esp_err_t read_body(esp_http_client_handle_t client, char **out, int *out_len) {
+    const int total = 8 * 1024;
+    char *buf = malloc(total + 1);
+    if (!buf) return ESP_ERR_NO_MEM;
+    int len = 0, n;
+    while (len < total && (n = esp_http_client_read(client, buf + len, total - len)) > 0) {
+        len += n;
+    }
+    buf[len] = 0;
+    *out = buf;
+    *out_len = len;
+    return ESP_OK;
+}
+
+esp_err_t tasks_client_fetch(task_item_t *out, int max, int *count) {
+    *count = 0;
+    char url[160];
+    snprintf(url, sizeof(url), "%s/tasks", APP_BRIDGE_URL);
+
+    esp_http_client_config_t cfg = { .url = url, .timeout_ms = 3000 };
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) return ESP_FAIL;
+
+    char *body = NULL;
+    int body_len = 0;
+    esp_err_t err = esp_http_client_open(client, 0);
+    int status = 0;
+    if (err == ESP_OK) {
+        if (esp_http_client_fetch_headers(client) < 0) err = ESP_FAIL;
+        status = esp_http_client_get_status_code(client);
+        if (err == ESP_OK && status >= 200 && status < 300) {
+            err = read_body(client, &body, &body_len);
+        } else if (err == ESP_OK) {
+            err = ESP_FAIL;
+        }
+        esp_http_client_close(client);
+    }
+    if (err != ESP_OK && status >= 400) {
+        ESP_LOGE(TAG, "GET /tasks HTTP %d", status);
+    }
+    if (err != ESP_OK) {
+        esp_http_client_cleanup(client);
+        return err;
+    }
+    esp_http_client_cleanup(client);
+
+    cJSON *root = cJSON_Parse(body);
+    free(body);
+    if (!root) {
+        ESP_LOGE(TAG, "invalid tasks JSON");
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    cJSON *arr = cJSON_IsArray(root) ? root : cJSON_GetObjectItem(root, "tasks");
+    int n = 0;
+    cJSON *entry;
+    cJSON_ArrayForEach(entry, arr) {
+        if (n >= max) break;
+        task_item_t *item = &out[n];
+        memset(item, 0, sizeof(*item));
+        const cJSON *f;
+        if ((f = cJSON_GetObjectItem(entry, "id"))) {
+            char *s = cJSON_GetStringValue(f);
+            if (s) strncpy(item->id, s, TASK_ID_LEN - 1);
+        }
+        if ((f = cJSON_GetObjectItem(entry, "title"))) {
+            char *s = cJSON_GetStringValue(f);
+            if (s) strncpy(item->title, s, TASK_TITLE_LEN - 1);
+        }
+        if ((f = cJSON_GetObjectItem(entry, "status"))) {
+            char *s = cJSON_GetStringValue(f);
+            if (s) strncpy(item->status, s, TASK_STATUS_LEN - 1);
+        }
+        if ((f = cJSON_GetObjectItem(entry, "message"))) {
+            char *s = cJSON_GetStringValue(f);
+            if (s) strncpy(item->message, s, TASK_MESSAGE_LEN - 1);
+        }
+        if ((f = cJSON_GetObjectItem(entry, "updated_at"))) {
+            item->updated_at = (int64_t)cJSON_GetNumberValue(f);
+        }
+        if (item->id[0] != 0) n++;
+    }
+    cJSON_Delete(root);
+    *count = n;
+    return ESP_OK;
+}
+
+esp_err_t tasks_client_post_feedback(const char *task_id, const void *pcm,
+                                     size_t bytes, uint32_t hz) {
+    char url[192];
+    snprintf(url, sizeof(url), "%s/feedback?task_id=%s&hz=%lu&bits=16&ch=1",
+             APP_BRIDGE_URL, task_id, (unsigned long)hz);
+
+    esp_http_client_config_t cfg = { .url = url, .timeout_ms = 10000 };
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) return ESP_FAIL;
+    esp_http_client_set_method(client, HTTP_METHOD_POST);
+    esp_http_client_set_header(client, "Content-Type", "application/octet-stream");
+
+    esp_err_t err = esp_http_client_open(client, (int)bytes);
+    if (err == ESP_OK) {
+        if (esp_http_client_write(client, pcm, (int)bytes) < 0) err = ESP_FAIL;
+    }
+    if (err == ESP_OK) {
+        err = esp_http_client_fetch_headers(client) >= 0 ? ESP_OK : ESP_FAIL;
+        int status = esp_http_client_get_status_code(client);
+        char drain[128] = { 0 };
+        esp_http_client_read(client, drain, sizeof(drain) - 1);
+        if (status < 200 || status >= 300) {
+            ESP_LOGE(TAG, "feedback 提交失败: HTTP %d %s", status, drain);
+            err = ESP_FAIL;
+        }
+    }
+    esp_http_client_cleanup(client);
+    return err;
+}

--- a/main/tasks_client.h
+++ b/main/tasks_client.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+#include "tasks_model.h"
+
+// 阻塞式请求，须在工作任务中调用。
+esp_err_t tasks_client_fetch(task_item_t *out, int max, int *count);
+
+// 把录音 PCM 提交给指定任务。bytes 为字节数。
+esp_err_t tasks_client_post_feedback(const char *task_id, const void *pcm,
+                                     size_t bytes, uint32_t hz);

--- a/main/tasks_model.c
+++ b/main/tasks_model.c
@@ -1,0 +1,80 @@
+#include "tasks_model.h"
+
+#include <string.h>
+
+static void copy_str(char *dst, size_t cap, const char *src) {
+    if (!src) src = "";
+    size_t n = strlen(src);
+    if (n >= cap) n = cap - 1;
+    memcpy(dst, src, n);
+    dst[n] = 0;
+}
+
+void tasks_model_init(tasks_model_t *m) {
+    memset(m, 0, sizeof(*m));
+}
+
+bool tasks_model_set_items(tasks_model_t *m, const task_item_t *items, int count) {
+    if (count < 0) count = 0;
+    if (count > TASKS_MODEL_MAX) count = TASKS_MODEL_MAX;
+
+    char keep_id[TASK_ID_LEN] = "";
+    if (m->count > 0 && m->selected >= 0 && m->selected < m->count) {
+        copy_str(keep_id, sizeof(keep_id), m->items[m->selected].id);
+    }
+
+    bool changed = (m->count != count);
+    for (int i = 0; i < count && !changed; i++) {
+        const task_item_t *a = &m->items[i];
+        const task_item_t *b = &items[i];
+        changed = strcmp(a->id, b->id) != 0 ||
+                  strcmp(a->title, b->title) != 0 ||
+                  strcmp(a->status, b->status) != 0 ||
+                  strcmp(a->message, b->message) != 0 ||
+                  a->updated_at != b->updated_at;
+    }
+    if (!changed) return false;
+
+    for (int i = 0; i < count; i++) m->items[i] = items[i];
+    m->count = count;
+
+    m->selected = 0;
+    for (int i = 0; i < count; i++) {
+        if (strcmp(m->items[i].id, keep_id) == 0) {
+            m->selected = i;
+            break;
+        }
+    }
+    return true;
+}
+
+void tasks_model_move(tasks_model_t *m, int delta) {
+    if (m->count <= 0) return;
+    int count = m->count;
+    m->selected = ((m->selected + delta) % count + count) % count;
+}
+
+const task_item_t *tasks_model_current(const tasks_model_t *m) {
+    if (m->count <= 0 || m->selected < 0 || m->selected >= m->count) return NULL;
+    return &m->items[m->selected];
+}
+
+task_chip_t tasks_model_chip(const char *status) {
+    if (!status) return TASK_CHIP_UNKNOWN;
+    if (strcmp(status, "queued") == 0) return TASK_CHIP_QUEUED;
+    if (strcmp(status, "running") == 0 || strcmp(status, "in_progress") == 0) return TASK_CHIP_RUNNING;
+    if (strcmp(status, "done") == 0 || strcmp(status, "completed") == 0) return TASK_CHIP_DONE;
+    if (strcmp(status, "failed") == 0 || strcmp(status, "error") == 0) return TASK_CHIP_FAILED;
+    return TASK_CHIP_UNKNOWN;
+}
+
+int tasks_model_preview(const char *message, char *out, size_t cap) {
+    if (cap == 0) return 0;
+    if (!message) message = "";
+    size_t line = 0;
+    while (message[line] != 0 && message[line] != '\n') line++;
+    size_t n = line < cap - 1 ? line : cap - 1;
+    memcpy(out, message, n);
+    out[n] = 0;
+    return (int)n;
+}

--- a/main/tasks_model.h
+++ b/main/tasks_model.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// 任务列表的纯逻辑：条目结构、选择循环、状态归类、单行预览。
+// 与 ESP-IDF/LVGL 无关，host tests 直接覆盖。
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define TASKS_MODEL_MAX     8
+#define TASK_ID_LEN         40
+#define TASK_TITLE_LEN      80
+#define TASK_STATUS_LEN     16
+#define TASK_MESSAGE_LEN    192
+
+typedef enum {
+    TASK_CHIP_QUEUED = 0,
+    TASK_CHIP_RUNNING,
+    TASK_CHIP_DONE,
+    TASK_CHIP_FAILED,
+    TASK_CHIP_UNKNOWN,
+} task_chip_t;
+
+typedef struct {
+    char id[TASK_ID_LEN];
+    char title[TASK_TITLE_LEN];
+    char status[TASK_STATUS_LEN];
+    char message[TASK_MESSAGE_LEN];
+    int64_t updated_at;                 // epoch 秒；服务器缺省时为 0
+} task_item_t;
+
+typedef struct {
+    task_item_t items[TASKS_MODEL_MAX];
+    int count;
+    int selected;
+} tasks_model_t;
+
+void tasks_model_init(tasks_model_t *m);
+
+// 用新条目整体替换；内容有变化时返回 true（selected 保持在同一 id 上）。
+bool tasks_model_set_items(tasks_model_t *m, const task_item_t *items, int count);
+
+void tasks_model_move(tasks_model_t *m, int delta);
+const task_item_t *tasks_model_current(const tasks_model_t *m);
+
+task_chip_t tasks_model_chip(const char *status);
+
+// 取 message 的第一行；超出 cap-1 字节时硬截断（省略号交给 LVGL LONG_DOT 渲染）。
+// 返回写入字节数。
+int tasks_model_preview(const char *message, char *out, size_t cap);

--- a/tests/test_tasks_model.c
+++ b/tests/test_tasks_model.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+#include <string.h>
+
+#include "tasks_model.h"
+
+int main(void)
+{
+    tasks_model_t m;
+    tasks_model_init(&m);
+    assert(m.count == 0 && m.selected == 0);
+
+    task_item_t in[TASKS_MODEL_MAX];
+    memset(in, 0, sizeof(in));
+    strcpy(in[0].id, "a"); strcpy(in[0].title, "A"); strcpy(in[0].status, "running"); strcpy(in[0].message, "line1\nline2");
+    strcpy(in[1].id, "b"); strcpy(in[1].title, "B"); strcpy(in[1].status, "done");
+    strcpy(in[2].id, "c"); strcpy(in[2].title, "C"); strcpy(in[2].status, "queued");
+    assert(tasks_model_set_items(&m, in, 3) == true);
+    assert(m.count == 3 && m.selected == 0);
+    assert(tasks_model_set_items(&m, in, 3) == false);          // 内容未变
+
+    tasks_model_move(&m, 1);
+    assert(m.selected == 1);
+    tasks_model_move(&m, -2);
+    assert(m.selected == 2);                                    // 循环回绕
+    tasks_model_move(&m, 1);
+    assert(m.selected == 0);
+
+    // 选中项按 id 保持：b 被选中，重排后仍跟随
+    tasks_model_move(&m, 1);
+    assert(m.selected == 1);
+    task_item_t reordered[TASKS_MODEL_MAX];
+    memset(reordered, 0, sizeof(reordered));
+    reordered[0] = in[1]; reordered[1] = in[0]; reordered[2] = in[2];
+    assert(tasks_model_set_items(&m, reordered, 3) == true);
+    assert(m.selected == 0 && strcmp(m.items[0].id, "b") == 0);
+
+    assert(tasks_model_chip("running") == TASK_CHIP_RUNNING);
+    assert(tasks_model_chip("in_progress") == TASK_CHIP_RUNNING);
+    assert(tasks_model_chip("done") == TASK_CHIP_DONE);
+    assert(tasks_model_chip("completed") == TASK_CHIP_DONE);
+    assert(tasks_model_chip("failed") == TASK_CHIP_FAILED);
+    assert(tasks_model_chip("queued") == TASK_CHIP_QUEUED);
+    assert(tasks_model_chip("weird") == TASK_CHIP_UNKNOWN);
+    assert(tasks_model_chip(NULL) == TASK_CHIP_UNKNOWN);
+
+    char out[TASK_MESSAGE_LEN];
+    tasks_model_preview(in[0].message, out, sizeof(out));
+    assert(strcmp(out, "line1") == 0);                          // 只取第一行
+
+    char small[10];
+    tasks_model_preview("hello world", small, sizeof(small));
+    assert(strlen(small) == 9);                                 // 截断到 cap-1
+
+    char big[16];
+    tasks_model_preview("hello world and more", big, sizeof(big));
+    assert(strncmp(big, "hello", 5) == 0);
+    assert(strlen(big) == 15);
+
+    tasks_model_preview("", out, sizeof(out));
+    assert(out[0] == 0);
+    tasks_model_preview(NULL, out, sizeof(out));
+    assert(out[0] == 0);
+
+    assert(tasks_model_set_items(&m, in, TASKS_MODEL_MAX + 5) == true || true);
+    assert(m.count <= TASKS_MODEL_MAX);
+    return 0;
+}

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -28,6 +28,10 @@ run_static_checks() {
         tests/test_ui_pixel_math.c main/ui_pixel_math.c \
         -o "${test_dir}/test_ui_pixel_math"
     "${test_dir}/test_ui_pixel_math"
+    "${CC:-cc}" -std=c11 -Wall -Wextra -Werror -Imain \
+        tests/test_tasks_model.c main/tasks_model.c \
+        -o "${test_dir}/test_tasks_model"
+    "${test_dir}/test_tasks_model"
     python3 tests/test_verify_firmware.py
     rm -rf "${test_dir}"
     echo "Host tests: PASS"


### PR DESCRIPTION
## Summary

- Tasks menu page: Wi-Fi STA connection (credentials in gitignored `main/app_config.h`), 3-second polling of a local bridge server for up to 8 tasks with status chips and latest-message previews, a task detail view, and hold-OK-to-record 16 kHz mono PCM feedback posted over HTTP.
- Dependency-free `bridge/server.py`: serves `tasks.json` fresh on every request and archives feedback PCM as WAV files under `bridge/feedback/` with a JSONL log.
- Host tests for the task list model, wired into `tools/validate.sh`.

## Scope and compatibility

- Affected board/revision: None (no pin-map change)
- Affected subsystem: `main/` (new app page, Wi-Fi STA, HTTP client), `tools/validate.sh`, new `bridge/`
- Wiring or pin-map impact: None
- Flash, partition, or persistent-data impact: None
- Backward-compatibility impact: None (additive menu entry)

## Verification

| Check | Result | Evidence or notes |
| --- | --- | --- |
| Build | NOT RUN | ESP-IDF 5.5.3 not installed locally; PR CI `firmware-checks` covers the build |
| Host tests | PASS | `./tools/validate.sh --static` (repository checks, actionlint, host tests) |
| Device tests | NOT RUN | Pending flash with real Wi-Fi credentials |
| Unverified | — | On-device Wi-Fi connect, bridge polling, recording quality, panel rendering |

Commands run:

```text
./tools/validate.sh --static
```

## Device evidence

Not yet — hardware pending flash.

## Checklist

- [x] I reviewed the complete diff and excluded unrelated/generated files.
- [x] I ran the relevant validation command or explained why it was not run.
- [x] I separated build, host-test, and device-test results.
- [x] I updated authoritative documentation for changed hardware facts or durable behavior.
- [x] I updated `docs/CHANGELOG.md` if this changes user-visible behavior, compatibility, or release workflow.
- [x] I removed credentials, private device links, personal data, and unsanitized logs.
